### PR TITLE
fix: corrige inicialização da lista de categorias

### DIFF
--- a/bugs/Dima.Web/Pages/Categories/List.razor.cs
+++ b/bugs/Dima.Web/Pages/Categories/List.razor.cs
@@ -11,7 +11,7 @@ public partial class ListCategoriesPage : ComponentBase
     #region Properties
 
     public bool IsBusy { get; set; } = false;
-    public List<Category> Categories { get; set; }
+    public List<Category> Categories { get; set; } = [];
     public string SearchTerm { get; set; } = string.Empty;
 
     #endregion


### PR DESCRIPTION
Uma lista de objetos precisa ser inicializada antes de qualquer operação.

Fixes: #3 